### PR TITLE
Rewrite the logpump to be cleaner and remove bugs

### DIFF
--- a/src/commands/debug/test.rs
+++ b/src/commands/debug/test.rs
@@ -3,7 +3,7 @@ use crate::core::CommandContext;
 use crate::error::CommandResult;
 
 pub async fn test(ctx: CommandContext) -> CommandResult {
-    for _ in 1..60 {
+    for _ in 1..5 {
         ctx.log(
             LogType::CommandUsed {
                 command: "test".to_string(),

--- a/src/core/guild_config.rs
+++ b/src/core/guild_config.rs
@@ -38,7 +38,7 @@ pub struct MessageLogs {
     pub ignore_bots: bool,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
 pub enum LogStyle {
     Text,
     Embed,


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
In the middle of updating to Tokio 1.0, I noticed that some of the channel logic in the logpump seemed off. I left a TODO and then poked more after.

There were a number of things that ended up being off, but most notably:
- Pump tasks were overly complicated for essentially just wanting to take a batch and make sure its sent. There was a chance the `todo` len checks and the receiver would cause pump tasks to spawn undersaturated. 
- `send` had an unwrap that wasn't infallible.
-  `receive_up_to` had a bug in its loop where it would lock up waiting for messages in a slow period if less then `count` were sent, causing huge delays.

Overall its much easier to follow and the typesystem proves more invariants. I'd like to write tests but I need to do some work first to make `ctx` testable at all @.@  

**Migration**
None

**Dependencies**
Nope
